### PR TITLE
Remove assessment year from label

### DIFF
--- a/main.js
+++ b/main.js
@@ -970,7 +970,7 @@ Mapboard.default({
                 }
               },
               {
-                label: 'Assessed Value ' + new Date().getFullYear(),
+                label: 'Latest Assessed Value',
                 value: function(state) {
                   var data = state.sources.opa.data;
                   // return data.market_value;


### PR DESCRIPTION
Just an idea, particularly for a short-term fix. Ideally we'd show which year it represents, but we'd need to query the assessment histories table to get the year. The regular properties table doesn't include what year `market_value` represents from what I can tell.