### PR TITLE
Use carto endpoint for property assessments data

### DIFF
--- a/main.js
+++ b/main.js
@@ -217,13 +217,13 @@ Mapboard.default({
     // },
     opa: {
       type: 'http-get',
-      url: 'https://data.phila.gov/resource/w7rb-qrn8.json',
+      url: 'https://phl.carto.com/api/v2/sql',
       options: {
         params: {
-          parcel_number: function(feature) { return feature.properties.opa_account_num; }
+          q: function(feature) { return "select * from opa_properties_public where parcel_number = '" + feature.properties.opa_account_num + "'" }
         },
         success: function(data) {
-          return data[0];
+          return data.rows[0];
         }
       }
     },


### PR DESCRIPTION
This removes the use of the deprecated [soda-carto](https://github.com/CityOfPhiladelphia/soda-carto) endpoint, which only exists to provide backwards compatibility for existing integrations with Socrata.

(You may want to apply this to cityatlas as well if it uses it)