### PR TITLE
new AGS for RegMaps tiles

### DIFF
--- a/src/general/imageOverlayGroups.js
+++ b/src/general/imageOverlayGroups.js
@@ -19,7 +19,7 @@ export default {
                 },
                 source: {
                   tiles: [ '\
-https://gis-svc.databridge.phila.gov/arcgis/rest/services/Atlas/RegMaps/MapServer/export?dpi=96\
+https://ags-regmaps.phila.gov/arcgis/rest/services/RegMaps/MapServer/export?dpi=96\
 &layerDefs=0:NAME=\'g' + item.properties.RECMAP.toLowerCase() + '.tif\'\
 &transparent=true\
 &format=png24\


### PR DESCRIPTION
DNS will be configured on Jan 16th, **do not merge before then!**

Insert new server URL for this little-known tile layer used in Atlas (available under the deeds tab under "Registry Maps" near the bottom. Have to have a property selected for it to appear)

Example URL:

https://ags-regmaps.phila.gov/arcgis/rest/services/RegMaps/MapServer/export?dpi=96&layerDefs=0:NAME=%27g005s22.tif%27&transparent=true&format=png24&bbox=-8366491.367982252,4857076.306839097,-8366453.149468109,4857114.525353242&bboxSR=3857&imageSR=3857&size=700,700&f=image&layers=show%3A0

I've confirmed this URL is publicly available, and also it's protected by our AGS WAF rules.